### PR TITLE
Added return value to callback to cancel poweroff

### DIFF
--- a/T4_PowerButton.h
+++ b/T4_PowerButton.h
@@ -52,12 +52,20 @@ enum arm_power_button_press_on_time {		//Time to switch on
 	arm_power_button_press_on_time_500ms = 0
 };
 
+enum callback_ex_action {
+	callback_ex_action_poweroff = 1,
+	callback_ex_action_poweroff_cancel = 0,
+	callback_ex_action_poweroff_keeparmed = 2
+};
+
 void arm_reset(void); // reset
 void arm_power_down(void); //switch off
 void set_arm_power_button_callback(void (*fun_ptr)(void));
+void set_arm_power_button_callback_ex(callback_ex_action (*fun_ptr)(void));
 void set_arm_power_button_debounce(arm_power_button_debounce debounce);
 void set_arm_power_button_press_time_emergency(arm_power_button_press_time_emergency emg);
 void set_arm_power_button_press_on_time(arm_power_button_press_on_time ontime);
+void rearm_power_button_callback(void);
 void arm_enable_nvram(void);
 
 bool arm_power_button_pressed(void);

--- a/examples/power/check_poweronoff_pressed.ino
+++ b/examples/power/check_poweronoff_pressed.ino
@@ -1,0 +1,70 @@
+#include <T4_PowerButton.h>
+
+IntervalTimer powerButtonWatchDogTimer;
+IntervalTimer somethingTimer;
+
+elapsedMicros elapsedFirst;
+
+void poweroff_cb()
+{
+    Serial.println("Powerbutton callback");
+    delay(200);
+}
+
+bool button_pressed = false;
+
+callback_ex_action poweroff_cb_ex()
+{
+    if(!button_pressed)
+    {
+        elapsedFirst = 0;
+        button_pressed = true;
+        Serial.println("powerdown pressed");
+    }
+    powerButtonWatchDogTimer.end();
+    powerButtonWatchDogTimer.begin(powerButtonWatchDog, 100000);
+    if(elapsedFirst > 10000000)
+      return callback_ex_action_poweroff;
+    return callback_ex_action_poweroff_keeparmed;
+}
+
+/*
+ * Without the watchdog calling rearm_power_button_callback(), normal 
+ * processing of loop() will never resume. IntervalTimers however will
+ */
+void powerButtonWatchDog()
+{
+    powerButtonWatchDogTimer.end(); // One Shot
+    rearm_power_button_callback();
+    button_pressed = false;
+    noInterrupts();
+    Serial.println("powerdown released");
+    interrupts();
+}
+
+void something()
+{
+    Serial.printf("something: %d\n", arm_power_button_pressed());
+}
+
+void setup() {
+
+    while(!Serial);
+    Serial.begin(9600);
+    delay(1000);
+    Serial.printf("Hello\n");
+    progInfo();
+    delay(1000);
+    somethingTimer.begin(something, 1000000);  // Check buttons and leds every 0.001 sec
+    set_arm_power_button_press_time_emergency(arm_power_button_press_time_emergency_off);
+    // Both callbacks may be installed
+    //set_arm_power_button_callback(poweroff_cb);
+    set_arm_power_button_callback_ex(poweroff_cb_ex);
+}
+
+void loop() {
+    noInterrupts(); // Otherwise Serial gets messed up
+    Serial.printf("Main\n");
+    interrupts();
+    delay(2000);
+}


### PR DESCRIPTION
I've modified the library and added a second callback install function that takes an callback returning a value. This value indicated whether the poweroff should be performed, cancelled, or whether the callback should be called again while the poweron/off line is low.

`void set_arm_power_button_callback_ex(callback_ex_action (*fun_ptr)(void));`

Example:

```
#include <T4_PowerButton.h>

int poweroff_count = 0;

callback_ex_action poweroff_cb_ex() {
    if(++poweroff_count == 3)
        return callback_ex_action_poweroff;
    return callback_ex_action_poweroff_cancel;
}

void setup() {

    while(!Serial);
    Serial.begin(9600);
    Serial.printf("Hello\n");
    delay(1000);
    set_arm_power_button_press_time_emergency(arm_power_button_press_time_emergency_off);
    set_arm_power_button_callback_ex(poweroff_cb_ex);
}

void loop() {
    Serial.printf("Main\n");
    delay(2000);
}
```

This callback can coexist with the original callback, so existing code *should* not break.

Changed one existing function, because as far as I can see it didn't work properly. But  this might also plain right stupidity on my side :-)

```
// I think bit 18 should be checked instead bit 17
bool arm_power_button_pressed(void) {
  return (SNVS_LPSR >> 18) & 0x01;
}

```
